### PR TITLE
Adding SVN lock Info popup

### DIFF
--- a/SVNToolBox/META-INF/plugin.xml
+++ b/SVNToolBox/META-INF/plugin.xml
@@ -97,6 +97,10 @@
             text="Copy URL">
       <add-to-group group-id="SubversionFilePopupGroup" anchor="last" />
     </action>
+    <action id="SvnToolBox.showLockInfo" class="zielu.svntoolbox.ui.actions.ShowLockInfoAction" text="Show Info...">
+      <add-to-group group-id="SubversionFilePopupGroup" anchor="last" />
+      <keyboard-shortcut keymap="$default" first-keystroke="ctrl I"/>
+    </action>
   </actions>
 
   <extensionPoints>

--- a/SVNToolBox/META-INF/plugin.xml
+++ b/SVNToolBox/META-INF/plugin.xml
@@ -97,7 +97,7 @@
             text="Copy URL">
       <add-to-group group-id="SubversionFilePopupGroup" anchor="last" />
     </action>
-    <action id="SvnToolBox.showLockInfo" class="zielu.svntoolbox.ui.actions.ShowLockInfoAction" text="Show Info...">
+    <action id="SvnToolBox.showLockInfo" class="zielu.svntoolbox.ui.actions.ShowLockInfoAction" text="Show Lock Info...">
       <add-to-group group-id="SubversionFilePopupGroup" anchor="last" />
       <keyboard-shortcut keymap="$default" first-keystroke="ctrl I"/>
     </action>

--- a/SVNToolBox/src/zielu/svntoolbox/FileStatusCalculator.java
+++ b/SVNToolBox/src/zielu/svntoolbox/FileStatusCalculator.java
@@ -128,7 +128,7 @@ public class FileStatusCalculator {
                 watch.tick("Base Name");
                 watch.stop();
                 return Optional.of(new FileStatus(fileUrl, baseName));
-            } catch (VcsException e) {
+            } catch (Exception e) {
                 LOG.error("Could not get branch configuration", e);
             }            
         } else {

--- a/SVNToolBox/src/zielu/svntoolbox/SvnToolBoxBundle.properties
+++ b/SVNToolBox/src/zielu/svntoolbox/SvnToolBoxBundle.properties
@@ -1,6 +1,7 @@
 action.show.module.decorations=Show module branches in Project View
 action.show.switched.decorations=Show switched branches in Project View
 action.copy.file.url=Copy URL
+action.show.lock.info=Show Lock Info...
 
 status.svn.prefix=Svn:
 status.svn.na=N/A
@@ -12,3 +13,9 @@ configurable.app.displayName=Svn ToolBox
 configurable.app.projectViewDecoration.text=Project View Decorations
 configurable.app.regularColor.text=Regular theme color
 configurable.app.darkColor.text=Dark theme color
+
+configurable.app.svnlock.title=Svn Lock Info
+configurable.app.svnlock.owner.label=Lock Owner
+configurable.app.svnlock.comment.label=Lock Comment
+configurable.app.svnlock.creation.label=Lock Creation Date
+configurable.app.svnlock.expiration.label=Lock Expiration Date

--- a/SVNToolBox/src/zielu/svntoolbox/config/SvnToolBoxAppState.java
+++ b/SVNToolBox/src/zielu/svntoolbox/config/SvnToolBoxAppState.java
@@ -45,6 +45,8 @@ public class SvnToolBoxAppState implements PersistentStateComponent<SvnToolBoxAp
     public int darkG = 107;
     public int darkB = 0;
 
+    private String fileCsv;
+
     @Transient
     private static final Color defaultRegularColor = new Color(159, 107, 0);
 
@@ -57,6 +59,13 @@ public class SvnToolBoxAppState implements PersistentStateComponent<SvnToolBoxAp
         return ApplicationManager.getApplication().getComponent(SvnToolBoxAppState.class);
     }
 
+    public String getCsvFile() {
+        return fileCsv;
+    }
+
+    public void setCsvFile(String fileCsv) {
+        this.fileCsv = fileCsv;
+    }
     @Transient
     public Color getCurrentRegularDecorationColor() {
         if (customRegularColor) {

--- a/SVNToolBox/src/zielu/svntoolbox/ui/actions/ShowLockInfoAction.java
+++ b/SVNToolBox/src/zielu/svntoolbox/ui/actions/ShowLockInfoAction.java
@@ -18,6 +18,10 @@ import org.tmatesoft.svn.core.wc.SVNRevision;
 
 import javax.swing.*;
 import java.awt.datatransfer.StringSelection;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.List;
 
 import static com.google.common.collect.Iterables.getLast;
@@ -90,4 +94,41 @@ public class ShowLockInfoAction extends VirtualFileUnderSvnActionBase {
             return;
         }
     }
+
+    private String run(String owner) {
+
+        String csvFile = "/Users/mkyong/Downloads/GeoIPCountryWhois.csv";
+        BufferedReader br = null;
+        String line = "";
+        String cvsSplitBy = ";";
+
+        try {
+
+            br = new BufferedReader(new FileReader(csvFile));
+            while ((line = br.readLine()) != null) {
+
+                // use comma as separator
+                String[] users = line.split(cvsSplitBy);
+
+                if(owner.equalsIgnoreCase(users[0])) {
+                    return "[" + users[0] + "] " + users[1];
+                }
+            }
+
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            if (br != null) {
+                try {
+                    br.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return "";
+    }
+
 }

--- a/SVNToolBox/src/zielu/svntoolbox/ui/actions/ShowLockInfoAction.java
+++ b/SVNToolBox/src/zielu/svntoolbox/ui/actions/ShowLockInfoAction.java
@@ -1,0 +1,93 @@
+package zielu.svntoolbox.ui.actions;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.ide.CopyPasteManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.components.JBList;
+import com.jgoodies.common.base.Strings;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.idea.svn.SvnVcs;
+import org.jetbrains.idea.svn.commandLine.SvnBindException;
+import org.jetbrains.idea.svn.info.Info;
+import org.jetbrains.idea.svn.lock.Lock;
+import org.tmatesoft.svn.core.wc.SVNRevision;
+
+import javax.swing.*;
+import java.awt.datatransfer.StringSelection;
+import java.util.List;
+
+import static com.google.common.collect.Iterables.getLast;
+import static org.apache.commons.lang.StringUtils.EMPTY;
+import static zielu.svntoolbox.SvnToolBoxBundle.getString;
+
+/**
+ * <p></p>
+ * <br/>
+ * <p>Created on 22.04.15</p>
+ *
+ * @author BONO Adil
+ */
+public class ShowLockInfoAction extends VirtualFileUnderSvnActionBase {
+
+    public ShowLockInfoAction() {
+        super(getString("action.show.lock.info"));
+    }
+
+    private static final String FIELD_DELIMITER = " : ";
+    private static final Splitter splitter = Splitter.on(FIELD_DELIMITER).trimResults();
+
+    @Override
+    protected void perform(AnActionEvent e, @NotNull Project project, @NotNull VirtualFile file) {
+        //get url
+        SvnVcs svn = SvnVcs.getInstance(project);
+        Info fileInfo = svn.getInfo(file);
+        if (fileInfo == null) {
+            return ;
+        }
+
+        //get lock infos
+        try {
+            Info urlInfo = svn.getInfo(fileInfo.getURL(), SVNRevision.UNDEFINED);
+            if(urlInfo == null)
+                return;
+
+            List<String> datas = Lists.newArrayList();
+
+            Lock lock = urlInfo.getLock();
+            if(lock != null) {
+                datas.add(getString("configurable.app.svnlock.owner.label") + FIELD_DELIMITER + lock.getOwner());
+                datas.add(getString("configurable.app.svnlock.comment.label") + FIELD_DELIMITER + lock.getComment());
+                datas.add(getString("configurable.app.svnlock.creation.label") + FIELD_DELIMITER + (lock.getCreationDate() != null ? lock.getCreationDate() : EMPTY));
+                datas.add(getString("configurable.app.svnlock.expiration.label") + FIELD_DELIMITER + (lock.getExpirationDate() != null ? lock.getExpirationDate() : EMPTY));
+            }
+
+            final JList list = new JBList(datas);
+
+            JBPopupFactory.getInstance()
+                .createListPopupBuilder(list)
+                .setTitle(getString("configurable.app.svnlock.title"))
+                .setResizable(true)
+                .setItemChoosenCallback(new Runnable() {
+                        public void run() {
+                            if (list.getSelectedIndices().length > 0) {
+                                String selectedValue = (String) list.getSelectedValue();
+
+                                if (Strings.isNotBlank(selectedValue) && selectedValue.contains(FIELD_DELIMITER)) {
+                                    CopyPasteManager.getInstance().setContents(new StringSelection(getLast(splitter.split(selectedValue))));
+                                }
+                            }
+                        }
+                    }
+                ).createPopup().showInFocusCenter();
+
+
+        } catch (SvnBindException sbe) {
+            sbe.printStackTrace();
+            return;
+        }
+    }
+}

--- a/SVNToolBox/src/zielu/svntoolbox/ui/config/SvnToolBoxConfigurable.java
+++ b/SVNToolBox/src/zielu/svntoolbox/ui/config/SvnToolBoxConfigurable.java
@@ -3,8 +3,11 @@
  */
 package zielu.svntoolbox.ui.config;
 
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.options.BaseConfigurable;
 import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.Nullable;
 import zielu.svntoolbox.SvnToolBoxBundle;
@@ -21,6 +24,7 @@ import javax.swing.JComponent;
  */
 public class SvnToolBoxConfigurable extends BaseConfigurable {
     private SvnToolBoxForm form;
+    private Project project;
 
     @Nls
     @Override
@@ -47,6 +51,12 @@ public class SvnToolBoxConfigurable extends BaseConfigurable {
         SvnToolBoxAppState state = SvnToolBoxAppState.getInstance();
         form.setRegularColorState(state.customRegularColor, state.getRegularDecorationColor());
         form.setDarkColorState(state.customDarkColor, state.getDarkDecorationColor());
+
+        form.getCsvFile().addBrowseFolderListener("",
+                "",
+                ProjectManager.getInstance().getDefaultProject(),
+                FileChooserDescriptorFactory.createSingleFileDescriptor("csv"));
+
         return form.getContent();
     }
 
@@ -56,6 +66,12 @@ public class SvnToolBoxConfigurable extends BaseConfigurable {
         SvnToolBoxAppState state = SvnToolBoxAppState.getInstance();
 
         boolean changed = false;
+
+        if(!state.getCsvFile().equalsIgnoreCase(form.getCsvFile().getText())){
+            state.setCsvFile(form.getCsvFile().getText());
+            changed = true;
+        }
+
         if (state.checkRegularDecorationChanged(form.isRegularColorEnabled(), form.getRegularColor())) {
             state.setRegularDecorationColor(form.isRegularColorEnabled(), form.getRegularColor());
             changed = true;
@@ -74,6 +90,10 @@ public class SvnToolBoxConfigurable extends BaseConfigurable {
     public boolean isModified() {
         boolean modified = false;
         SvnToolBoxAppState state = SvnToolBoxAppState.getInstance();
+
+        if(!state.getCsvFile().equalsIgnoreCase(form.getCsvFile().getText())){
+            modified = true;
+        }
         if (state.checkRegularDecorationChanged(form.isRegularColorEnabled(), form.getRegularColor())) {
             modified = true;
         }
@@ -87,6 +107,8 @@ public class SvnToolBoxConfigurable extends BaseConfigurable {
     public void reset() {
         initComponent();
         SvnToolBoxAppState state = SvnToolBoxAppState.getInstance();
+
+        form.getCsvFile().setText(state.getCsvFile());
         form.setRegularColorState(state.customRegularColor, state.getRegularDecorationColor());
         form.setDarkColorState(state.customDarkColor, state.getDarkDecorationColor());
     }

--- a/SVNToolBox/src/zielu/svntoolbox/ui/config/SvnToolBoxForm.form
+++ b/SVNToolBox/src/zielu/svntoolbox/ui/config/SvnToolBoxForm.form
@@ -37,11 +37,11 @@
         <properties/>
         <border type="etched" title-resource-bundle="zielu/svntoolbox/SvnToolBoxBundle" title-key="configurable.app.projectViewDecoration.text"/>
         <children>
-          <component id="f1344" class="javax.swing.JFileChooser" binding="csvFileChooser" default-binding="true">
+          <component id="f1344" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="csvFileChooser" default-binding="true">
             <constraints border-constraint="Center"/>
             <properties>
-              <acceptAllFileFilterUsed value="true"/>
-              <controlButtonsAreShown value="false"/>
+              <editable value="true"/>
+              <enabled value="true"/>
             </properties>
           </component>
           <component id="f077" class="javax.swing.JLabel">

--- a/SVNToolBox/src/zielu/svntoolbox/ui/config/SvnToolBoxForm.form
+++ b/SVNToolBox/src/zielu/svntoolbox/ui/config/SvnToolBoxForm.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="zielu.svntoolbox.ui.config.SvnToolBoxForm">
-  <grid id="27dc6" binding="content" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="content" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="500" height="400"/>
+      <xy x="20" y="20" width="741" height="423"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -27,9 +27,31 @@
       </grid>
       <vspacer id="7b50a">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
+      <grid id="7fb4a" layout-manager="BorderLayout" hgap="0" vgap="0">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="etched" title-resource-bundle="zielu/svntoolbox/SvnToolBoxBundle" title-key="configurable.app.projectViewDecoration.text"/>
+        <children>
+          <component id="f1344" class="javax.swing.JFileChooser" binding="csvFileChooser" default-binding="true">
+            <constraints border-constraint="Center"/>
+            <properties>
+              <acceptAllFileFilterUsed value="true"/>
+              <controlButtonsAreShown value="false"/>
+            </properties>
+          </component>
+          <component id="f077" class="javax.swing.JLabel">
+            <constraints border-constraint="West"/>
+            <properties>
+              <text value="Owner csv binding file : (ex. owner;value) : "/>
+            </properties>
+          </component>
+        </children>
+      </grid>
     </children>
   </grid>
 </form>

--- a/SVNToolBox/src/zielu/svntoolbox/ui/config/SvnToolBoxForm.java
+++ b/SVNToolBox/src/zielu/svntoolbox/ui/config/SvnToolBoxForm.java
@@ -6,8 +6,7 @@ package zielu.svntoolbox.ui.config;
 import com.intellij.ui.CheckBoxWithColorChooser;
 import zielu.svntoolbox.SvnToolBoxBundle;
 
-import javax.swing.JComponent;
-import javax.swing.JPanel;
+import javax.swing.*;
 import java.awt.Color;
 
 /**
@@ -21,6 +20,7 @@ public class SvnToolBoxForm {
     private JPanel content;
     private CheckBoxWithColorChooser regularColorChooser;
     private CheckBoxWithColorChooser darkColorChooser;
+    private JFileChooser csvFileChooser;
 
     public JComponent getContent() {
         return content;
@@ -29,6 +29,7 @@ public class SvnToolBoxForm {
     protected void createUIComponents() {
         regularColorChooser = new CheckBoxWithColorChooser(SvnToolBoxBundle.getString("configurable.app.regularColor.text"));
         darkColorChooser = new CheckBoxWithColorChooser(SvnToolBoxBundle.getString("configurable.app.darkColor.text"));
+        csvFileChooser = new JFileChooser("/");
     }
 
     public boolean isRegularColorEnabled() {

--- a/SVNToolBox/src/zielu/svntoolbox/ui/config/SvnToolBoxForm.java
+++ b/SVNToolBox/src/zielu/svntoolbox/ui/config/SvnToolBoxForm.java
@@ -3,6 +3,7 @@
  */
 package zielu.svntoolbox.ui.config;
 
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.ui.CheckBoxWithColorChooser;
 import zielu.svntoolbox.SvnToolBoxBundle;
 
@@ -20,7 +21,7 @@ public class SvnToolBoxForm {
     private JPanel content;
     private CheckBoxWithColorChooser regularColorChooser;
     private CheckBoxWithColorChooser darkColorChooser;
-    private JFileChooser csvFileChooser;
+    private TextFieldWithBrowseButton csvFileChooser;
 
     public JComponent getContent() {
         return content;
@@ -29,7 +30,15 @@ public class SvnToolBoxForm {
     protected void createUIComponents() {
         regularColorChooser = new CheckBoxWithColorChooser(SvnToolBoxBundle.getString("configurable.app.regularColor.text"));
         darkColorChooser = new CheckBoxWithColorChooser(SvnToolBoxBundle.getString("configurable.app.darkColor.text"));
-        csvFileChooser = new JFileChooser("/");
+        csvFileChooser = new TextFieldWithBrowseButton();
+    }
+
+    public TextFieldWithBrowseButton getCsvFile() {
+        return csvFileChooser;
+    }
+
+    public void setCsvFile(TextFieldWithBrowseButton csvFileChooser) {
+        this.csvFileChooser = csvFileChooser;
     }
 
     public boolean isRegularColorEnabled() {


### PR DESCRIPTION
Hello,
I've added a popup that shows lock info, these informations are not available in the current version of svn4idea plugin and SVNToolBox either. it's useful in my case to determine who lock files, to be able to commit changes.
Actually this popup shows (Lock Owner, Lock Comment, Lock Creation & Expiration Date) and put values in the clipboard on click.
![menu](https://cloud.githubusercontent.com/assets/795889/7294472/054e3486-e9ae-11e4-9998-9d60e2d9b38a.png)
![popup](https://cloud.githubusercontent.com/assets/795889/7294473/055052de-e9ae-11e4-8406-f5d9f4af7cde.png)

And also a configuration param that permit to add a csv file to map Lock Owner with another value.
![image](https://cloud.githubusercontent.com/assets/795889/7366924/ed776c0a-ed9b-11e4-87c0-5fd681720a55.png)



Best Regards.