### PR TITLE
ABO add svn info owner csv binding

### DIFF
--- a/SVNToolBox/src/zielu/svntoolbox/SvnToolBoxBundle.properties
+++ b/SVNToolBox/src/zielu/svntoolbox/SvnToolBoxBundle.properties
@@ -11,6 +11,7 @@ status.svn.pending=loading...
 
 configurable.app.displayName=Svn ToolBox
 configurable.app.projectViewDecoration.text=Project View Decorations
+configurable.app.svninfocsv.text=Lock Owner value mapping
 configurable.app.regularColor.text=Regular theme color
 configurable.app.darkColor.text=Dark theme color
 

--- a/SVNToolBox/src/zielu/svntoolbox/config/SvnToolBoxAppState.java
+++ b/SVNToolBox/src/zielu/svntoolbox/config/SvnToolBoxAppState.java
@@ -3,6 +3,7 @@
  */
 package zielu.svntoolbox.config;
 
+import com.google.common.base.Strings;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ApplicationComponent;
 import com.intellij.openapi.components.PersistentStateComponent;
@@ -60,12 +61,13 @@ public class SvnToolBoxAppState implements PersistentStateComponent<SvnToolBoxAp
     }
 
     public String getCsvFile() {
-        return fileCsv;
+        return Strings.nullToEmpty(fileCsv);
     }
 
     public void setCsvFile(String fileCsv) {
         this.fileCsv = fileCsv;
     }
+
     @Transient
     public Color getCurrentRegularDecorationColor() {
         if (customRegularColor) {

--- a/SVNToolBox/src/zielu/svntoolbox/ui/actions/ShowLockInfoAction.java
+++ b/SVNToolBox/src/zielu/svntoolbox/ui/actions/ShowLockInfoAction.java
@@ -15,6 +15,7 @@ import org.jetbrains.idea.svn.commandLine.SvnBindException;
 import org.jetbrains.idea.svn.info.Info;
 import org.jetbrains.idea.svn.lock.Lock;
 import org.tmatesoft.svn.core.wc.SVNRevision;
+import zielu.svntoolbox.config.SvnToolBoxAppState;
 
 import javax.swing.*;
 import java.awt.datatransfer.StringSelection;
@@ -63,7 +64,7 @@ public class ShowLockInfoAction extends VirtualFileUnderSvnActionBase {
 
             Lock lock = urlInfo.getLock();
             if(lock != null) {
-                datas.add(getString("configurable.app.svnlock.owner.label") + FIELD_DELIMITER + lock.getOwner());
+                datas.add(getString("configurable.app.svnlock.owner.label") + FIELD_DELIMITER + getOwnerCSVDetail(lock.getOwner()));
                 datas.add(getString("configurable.app.svnlock.comment.label") + FIELD_DELIMITER + lock.getComment());
                 datas.add(getString("configurable.app.svnlock.creation.label") + FIELD_DELIMITER + (lock.getCreationDate() != null ? lock.getCreationDate() : EMPTY));
                 datas.add(getString("configurable.app.svnlock.expiration.label") + FIELD_DELIMITER + (lock.getExpirationDate() != null ? lock.getExpirationDate() : EMPTY));
@@ -95,26 +96,27 @@ public class ShowLockInfoAction extends VirtualFileUnderSvnActionBase {
         }
     }
 
-    private String run(String owner) {
+    private String getOwnerCSVDetail(String owner) {
+        if(Strings.isBlank(owner))
+            return EMPTY;
 
-        String csvFile = "/Users/mkyong/Downloads/GeoIPCountryWhois.csv";
+        String csvFile = SvnToolBoxAppState.getInstance().getCsvFile();
+        if(Strings.isBlank(csvFile))
+            return owner;
+
         BufferedReader br = null;
-        String line = "";
-        String cvsSplitBy = ";";
-
         try {
-
             br = new BufferedReader(new FileReader(csvFile));
+            String line;
             while ((line = br.readLine()) != null) {
 
                 // use comma as separator
-                String[] users = line.split(cvsSplitBy);
+                String[] users = line.split(";");
 
                 if(owner.equalsIgnoreCase(users[0])) {
-                    return "[" + users[0] + "] " + users[1];
+                    return users[0] + " - " + users[1];
                 }
             }
-
         } catch (FileNotFoundException e) {
             e.printStackTrace();
         } catch (IOException e) {
@@ -128,7 +130,8 @@ public class ShowLockInfoAction extends VirtualFileUnderSvnActionBase {
                 }
             }
         }
-        return "";
+
+        return owner;
     }
 
 }

--- a/SVNToolBox/src/zielu/svntoolbox/ui/config/SvnToolBoxForm.form
+++ b/SVNToolBox/src/zielu/svntoolbox/ui/config/SvnToolBoxForm.form
@@ -35,7 +35,7 @@
           <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
-        <border type="etched" title-resource-bundle="zielu/svntoolbox/SvnToolBoxBundle" title-key="configurable.app.projectViewDecoration.text"/>
+        <border type="etched" title-resource-bundle="zielu/svntoolbox/SvnToolBoxBundle" title-key="configurable.app.svninfocsv.text"/>
         <children>
           <component id="f1344" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="csvFileChooser" default-binding="true">
             <constraints border-constraint="Center"/>


### PR DESCRIPTION
Missing commit. That implement lock owner csv binding.
In the actual version, the setting's option (binding file) is availble but not the code.
Sorry for the inconvenience.
